### PR TITLE
fix(server): appRouter doesn't exist

### DIFF
--- a/example/src/server.ts
+++ b/example/src/server.ts
@@ -1,6 +1,5 @@
 import * as trpcExpress from '@trpc/server/adapters/express';
 import express from 'express';
-import { appRouter } from '../prisma/trpc/routers/index';
 import { createContext } from './context';
 
 const PORT = 3001;


### PR DESCRIPTION
Automatically when you create the app it gives you the following error:
```[ERROR] 12:31:40 ⨯ Unable to compile TypeScript:
src/server.ts(3,27): error TS2307: Cannot find module '../prisma/trpc/routers/index' or its corresponding type declarations