### PR TITLE
Ensure fallbackRule is used when rule not found.

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -24,7 +24,7 @@ export function generateMiddlewareFromRuleTree(ruleTree: IRules, options: IOptio
   }) => {
     const opWithPath: Array<string> = path.split('.')
     const opName: string = opWithPath[opWithPath.length - 1]
-    const rule = ruleTree?.[type]?.[opName]
+    const rule = ruleTree?.[type]?.[opName] || options.fallbackRule;
 
     if (rule) {
       return rule?.resolve(ctx, type, path, rawInput, options).then((result: any) => {


### PR DESCRIPTION
Hey. I have been trying this out on a project and really need the fallbackRule (always deny!). I spotted that it was being ignored.