### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "prettier": "prettier --ignore-path .gitignore --write --list-different \"**/*.{ts,tsx,yml}\""
   },
   "devDependencies": {
-    "@types/node": "15.6.1",
-    "lint-staged": "11.2.6",
-    "prettier": "2.4.1",
+    "@types/node": "18.11.9",
+    "lint-staged": "13.0.3",
+    "prettier": "2.7.1",
     "pretty-quick": "3.1.3",
     "rimraf": "3.0.2",
-    "ts-node": "10.4.0",
-    "typescript": "4.3.5"
+    "ts-node": "10.9.1",
+    "typescript": "4.8.4"
   },
   "bugs": {
     "url": "https://github.com/omar-dulaimi/trpc-shield/issues"
@@ -36,6 +36,6 @@
   "homepage": "https://github.com/omar-dulaimi/trpc-shield#readme",
   "private": true,
   "dependencies": {
-    "@trpc/server": "^9.23.6"
+    "@trpc/server": "^10.0.0-rc.7"
   }
 }

--- a/src/shield.ts
+++ b/src/shield.ts
@@ -3,7 +3,7 @@ import { IRules, IOptions, IOptionsConstructor, ShieldRule, IFallbackErrorType }
 import { generateMiddlewareFromRuleTree } from './generator'
 import { allow } from './constructors'
 import { withDefault } from './utils'
-import { MiddlewareFunction } from '@trpc/server/dist/declarations/src/internals/middlewares'
+import { MiddlewareFunction } from '@trpc/server'
 
 /**
  *
@@ -34,7 +34,7 @@ function normalizeOptions(options: IOptionsConstructor): IOptions {
  * Validates rules and generates middleware from defined rule tree.
  *
  */
-export function shield(ruleTree: IRules, options: IOptionsConstructor = {}): MiddlewareFunction<any, any, any> {
+export function shield(ruleTree: IRules, options: IOptionsConstructor = {}): MiddlewareFunction<any, any> {
   const normalizedOptions = normalizeOptions(options)
   const ruleTreeValidity = validateRuleTree(ruleTree)
 


### PR DESCRIPTION
Hi 👋🏻 

Thanks for your packages, I've been testing the prisma/trpc/zod stack recently and your generators are awesome to get started.

This PR upgrades dependencies, namely `@trpc/server` to v10
It updates the import of `MiddlewareFunction` following the move to [reusable Middlewares](https://trpc.io/docs/middlewares)

This fixes some errors I had around the permissions types when using [omar-dulaimi/prisma-trpc-shield-generator ](https://github.com/omar-dulaimi/prisma-trpc-shield-generator) with a `@trpc/server^10` stack