### PR TITLE
Fix #17 - Only apply rule if the namespace is the proper one

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -35,14 +35,8 @@ export function generateMiddlewareFromRuleTree<TContext extends Record<string, u
       //@ts-ignore
       rule = ruleTree?.[type]?.[opName] || options.fallbackRule;
     } else {
-      for (const key of keys) {
-        //@ts-ignore
-        const namespace = ruleTree[key];
-        if (namespace?.[type]?.[opName]) {
-          rule = namespace?.[type]?.[opName] || options.fallbackRule;
-          break;
-        }
-      }
+      const namespace = opWithPath[0]
+      rule = namespace?.[type]?.[opName] ?? options.fallbackRule;
     }
 
     if (rule) {


### PR DESCRIPTION
This code uses the `opWithPath` variable to get the namespace, assuming it's the first item in the array.